### PR TITLE
Fix "\n" in the end of "mv" command

### DIFF
--- a/Translocation_calling/run_HiCtrans.pl
+++ b/Translocation_calling/run_HiCtrans.pl
@@ -28,7 +28,7 @@ if ($chrA ne "all" && $chrB ne "all"){
 	print out "mv $input $folder/\n";
 	print out "mv $chrA-$chrB $folder/\n";
 	print out "mv $chrA-$chrB.tmp.result $folder/\n";
-	print out "mv $chrA-$chrB.Translocation.result $folder/";
+	print out "mv $chrA-$chrB.Translocation.result $folder/\n";
 	
 	## 04/02/2018 ##
 	print out "mv $chrA-$chrB.Translocation.EntropyFiltered.result $folder/";


### PR DESCRIPTION
Missing "\n" generate an error while bash script execution: "mv: rename chr7_chr15_Folder/mv to chr7_chr15_Folder/mv: No such file or directory".
That's is the fix for that issue.